### PR TITLE
feat(load): allow adapter to accept credentials via composed plugin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   push:
-    branches: '*'
+    branches: '**'
     tags-ignore: '*'
 
 jobs:

--- a/deps_dev.js
+++ b/deps_dev.js
@@ -1,7 +1,11 @@
-export { assertEquals } from "https://deno.land/std@0.98.0/testing/asserts.ts";
+export {
+  assert,
+  assertEquals,
+} from "https://deno.land/std@0.98.0/testing/asserts.ts";
 
 export { default as appOpine } from "https://x.nest.land/hyper-app-opine@1.0.0/mod.js";
-export { default as core } from "https://x.nest.land/hyper@1.3.11/mod.js";
+export { default as core } from "https://x.nest.land/hyper@1.4.2/mod.js";
+export { default as validateFactorySchema } from "https://x.nest.land/hyper@1.4.2/utils/plugin-schema.js";
 
 export {
   adjectives,

--- a/mod.test.js
+++ b/mod.test.js
@@ -1,0 +1,72 @@
+import { assert, assertEquals, validateFactorySchema } from "./deps_dev.js";
+
+import createFactory from "./mod.js";
+
+const { test } = Deno;
+
+// TODO: probably a better way to do this
+console.log = () => {};
+
+test("should be a valid schema", () => {
+  const factory = createFactory("foo");
+  assert(validateFactorySchema(factory));
+});
+
+test("load - should return the object", () => {
+  const factory = createFactory("foo");
+  const res = factory.load();
+
+  assert(res.name);
+  assert(res.factory);
+  assert(res.aws);
+  assert(res.aws.s3);
+  assert(res.aws.sqs);
+});
+
+test("load - should use provided credentials", async () => {
+  const res = createFactory("foo", {
+    awsAccessKeyId: "foo",
+    awsSecretKey: "bar",
+    region: "fizz",
+  }).load();
+
+  await res.factory.ensureCredentialsAvailable();
+
+  assert(true);
+});
+
+test("load - should use credentials passed to load", async () => {
+  const res = createFactory("foo").load({
+    awsAccessKeyId: "foo",
+    awsSecretKey: "bar",
+    region: "fizz",
+  });
+
+  await res.factory.ensureCredentialsAvailable();
+  assert(true);
+});
+
+test("load - should merge credentials, preferring those passed to adapter", async () => {
+  const res = createFactory("foo", { awsAccessKeyId: "better-id" }).load({
+    awsAccessKeyId: "foo",
+    awsSecretKey: "bar",
+    region: "fizz",
+  });
+
+  await res.factory.ensureCredentialsAvailable();
+
+  assertEquals(res.awsAccessKeyId, "better-id");
+  assertEquals(res.awsSecretKey, "bar");
+  assertEquals(res.region, "fizz");
+});
+
+test("load - should default the region to us-east-1", async () => {
+  const res = createFactory("foo").load({
+    awsAccessKeyId: "foo",
+    awsSecretKey: "bar",
+  });
+
+  await res.factory.ensureCredentialsAvailable();
+
+  assertEquals(res.region, "us-east-1");
+});

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,4 +2,4 @@
 
 deno lint
 deno fmt --check
-DENO_ENV=test deno test --unstable -A adapter_test.js process-tasks_test.js
+DENO_ENV=test deno test --unstable -A adapter_test.js process-tasks_test.js mod.test.js


### PR DESCRIPTION
mirror of the work done on https://github.com/hyper63/hyper-adapter-s3/pull/3 . Couple small differences, but accomplishes the same goal. For this adapter, I needed to add a `redact` function, to ensure secrets weren't logged by the `tap`

Also added some coverage on `mod.js`