### PR TITLE
fix: deleteBucket return ok expected response

### DIFF
--- a/lib/s3/delete-bucket.js
+++ b/lib/s3/delete-bucket.js
@@ -4,5 +4,5 @@ export default (bucket) =>
   ask((s3) =>
     s3.deleteBucket(
       assoc("Bucket", `hyper-queue-${bucket}`, {}),
-    )
+    ).then(() => ({ ok: true }))
   );


### PR DESCRIPTION
[this line](https://github.com/hyper63/hyper-adapter-sqs/blob/a224cea75eba79c77e26bfc203ce84892bc7f9ed/adapter.js#L95) expects both `deleteQueue` and `deleteBucket` to return `{ ok: true }` on success. `deleteBucket` was not, although the delete was successful, causing `deleteQueue` on the adapter to return `{ ok: false }`.

This PR makes it such that `deleteBucket` returns `{ ok: true }` on success.