### PR TITLE
fix: format error to hyper error format

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -104,7 +104,7 @@ export function adapter({ name, aws: { s3, sqs } }) {
               .map((results) => ({
                 ok: all(equals(true), pluck("ok", results)),
               }))
-            : putObject(svcName, QUEUES, queues)
+            : putObject(svcName, QUEUES, queues).map(() => ({ ok: true }))
         )
         .bimap(
           toHyperErr,

--- a/adapter.js
+++ b/adapter.js
@@ -1,4 +1,5 @@
 import { crocks, R } from "./deps.js";
+import { toHyperErr } from "./lib/utils.js";
 import processTasks from "./process-tasks.js";
 
 const { Async } = crocks;
@@ -8,6 +9,7 @@ const {
   dissoc,
   equals,
   filter,
+  identity,
   keys,
   map,
   pluck,
@@ -58,7 +60,11 @@ export function adapter({ name, aws: { s3, sqs } }) {
 
   return Object.freeze({
     // list queues
-    index: () => getObject(svcName, QUEUES).map(keys).toPromise(),
+    index: () =>
+      getObject(svcName, QUEUES).map(keys).bimap(
+        toHyperErr,
+        identity,
+      ).toPromise(),
     // create queue
     create: ({ name, target, secret }) => {
       return Async.all([
@@ -75,6 +81,10 @@ export function adapter({ name, aws: { s3, sqs } }) {
         )
         .map(assoc(name, { target, secret }))
         .chain(putObject(svcName, QUEUES))
+        .bimap(
+          toHyperErr,
+          identity,
+        )
         .toPromise();
     },
     // delete queue
@@ -96,6 +106,10 @@ export function adapter({ name, aws: { s3, sqs } }) {
               }))
             : putObject(svcName, QUEUES, queues)
         )
+        .bimap(
+          toHyperErr,
+          identity,
+        )
         .toPromise(),
     // post job
     post: ({ name, job }) =>
@@ -106,6 +120,10 @@ export function adapter({ name, aws: { s3, sqs } }) {
         .chain(postJob(name))
         //.map(result => (console.log('result: ', result), result))
         .map(() => ({ ok: true }))
+        .bimap(
+          toHyperErr,
+          identity,
+        )
         .toPromise(),
     // get jobs
     get: ({ name, status }) =>
@@ -113,6 +131,10 @@ export function adapter({ name, aws: { s3, sqs } }) {
         .chain(includeDocs)
         .map(filter(propEq("status", status)))
         .map((jobs) => ({ ok: true, jobs, status }))
+        .bimap(
+          toHyperErr,
+          identity,
+        )
         .toPromise(),
     // retry job
     retry: ({ name, id }) =>
@@ -125,11 +147,19 @@ export function adapter({ name, aws: { s3, sqs } }) {
           }
           return Async.Resolved({ ok: true });
         })
+        .bimap(
+          toHyperErr,
+          identity,
+        )
         .toPromise(),
     // cancel job
     cancel: ({ name, id }) =>
       deleteObject(svcName, `${name}/${id}`)
         .map(() => ({ ok: true }))
+        .bimap(
+          toHyperErr,
+          identity,
+        )
         .toPromise(),
   });
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -85,6 +85,7 @@ export const mapStatus = cond([
 
 export const toHyperErr = (err) => ({
   ...err,
+  ok: false,
   status: mapStatus(err.status),
   msg: mapErr(err),
 });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,19 @@
 import { crocks, hmac, R } from "../deps.js";
 
 const { Reader } = crocks;
+const {
+  always,
+  cond,
+  ifElse,
+  is,
+  identity,
+  T,
+  join,
+  complement,
+  isNil,
+} = R;
 
+export const isDefined = complement(isNil);
 export const ask = Reader.ask;
 export const assoc = R.assoc;
 export const prop = R.prop;
@@ -18,3 +30,61 @@ export const computeSignature = (secret, payload, time) => {
   const signature = hmac("sha256", secret, msg, "utf8", "hex");
   return signature;
 };
+
+// always return a string
+export const mapErr = cond([
+  // string
+  [is(String), identity],
+  // { message } catches both Error, and Object with message prop
+  [
+    compose(
+      isDefined,
+      prop("message"),
+    ),
+    prop("message"),
+  ],
+  // { msg }
+  [
+    compose(
+      isDefined,
+      prop("msg"),
+    ),
+    prop("msg"),
+  ],
+  // []
+  [
+    is(Array),
+    compose(
+      join(", "),
+      (errs) => errs.map(mapErr), // recurse
+    ),
+  ],
+  // any non nil
+  [isDefined, (val) => JSON.stringify(val)],
+  // nil
+  [T, () => "An error occurred"],
+]);
+
+// always return a number or undefined
+export const mapStatus = cond([
+  [is(Number), identity],
+  [
+    is(String),
+    compose(
+      ifElse(
+        isNaN,
+        always(undefined),
+        identity,
+      ),
+      (status) => parseInt(status, 10),
+    ),
+  ],
+  // anything else
+  [T, always(undefined)],
+]);
+
+export const toHyperErr = (err) => ({
+  ...err,
+  status: mapStatus(err.status),
+  msg: mapErr(err),
+});

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,4 +2,4 @@
 
 deno lint
 deno fmt --check
-DENO_ENV=test deno test --unstable -A adapter_test.js process-tasks_test.js mod.test.js
+DENO_ENV=test deno test --unstable -A adapter_test.js process-tasks_test.js mod.test.js utils.test.js

--- a/utils.test.js
+++ b/utils.test.js
@@ -47,6 +47,7 @@ test("mapStatus - should not set status", () => {
 test("toHyperErr - should return a hyper error shape", () => {
   const err = toHyperErr({ message: "foo", status: 200, extra: "field" });
 
+  assertEquals(err.ok, false);
   assertEquals(err.msg, "foo");
   assertEquals(err.status, 200);
   assertEquals(err.extra, "field");

--- a/utils.test.js
+++ b/utils.test.js
@@ -1,0 +1,53 @@
+import { assertEquals } from "./deps_dev.js";
+
+import { mapErr, mapStatus, toHyperErr } from "./lib/utils.js";
+
+const { test } = Deno;
+
+test("mapErr - should return the string", () => {
+  const res = mapErr("foobar");
+
+  assertEquals(res, "foobar");
+});
+
+test("mapErr - should return the error message", () => {
+  const res = mapErr(new Error("foobar"));
+
+  assertEquals(res, "foobar");
+});
+
+test("mapErr - should return the object message", () => {
+  const res = mapErr({ message: "foobar" });
+
+  assertEquals(res, "foobar");
+});
+
+test("mapErr - should return the stringified thing", () => {
+  const res = mapErr({ foo: "bar" });
+
+  assertEquals(res, JSON.stringify({ foo: "bar" }));
+});
+
+test("mapErr - should return generic message", () => {
+  const res = mapErr(undefined);
+
+  assertEquals(res, "An error occurred");
+});
+
+test("mapStatus - should parse status", () => {
+  assertEquals(mapStatus("200"), 200);
+});
+
+test("mapStatus - should not set status", () => {
+  assertEquals(mapStatus("foo"), undefined);
+  assertEquals(mapStatus(undefined), undefined);
+  assertEquals(mapStatus({}), undefined);
+});
+
+test("toHyperErr - should return a hyper error shape", () => {
+  const err = toHyperErr({ message: "foo", status: 200, extra: "field" });
+
+  assertEquals(err.msg, "foo");
+  assertEquals(err.status, 200);
+  assertEquals(err.extra, "field");
+});


### PR DESCRIPTION
there was no formatting of errors leaving the adapter. This PR formats the errors to ensure they fit the "hyper style", that is having a `msg` and optional `status`. This style on based on what the `hyper-app-opine` is handling [here](https://github.com/hyper63/hyper/blob/66bc2b550a755587c9d69c6d356e0b79f05dd04f/packages/app-opine/utils.js#L9)

This might be a good candidate for a `hyper-utils` module, as we are using similar patterns in this adapter, s3, and namespaced-s3. I beefed up the handling in this PR, so otherwise, i'll need to backfill s3, and namespaced s3.

I could also see this code for mapping to a hyper error being in hyper core.