### PR TITLE
feat: add api to cleanup interval to prevent memory leaks

### DIFF
--- a/adapter.js
+++ b/adapter.js
@@ -38,8 +38,9 @@ export function adapter({ name, aws: { s3, sqs } }) {
   /*
     Listen for queue messages every 10 seconds
   */
+  let interval
   if (Deno.env.get("DENO_ENV") !== "test") {
-    setInterval(
+    interval = setInterval(
       () =>
         processTasks(svcName, asyncFetch, {
           getQueueUrl,
@@ -57,6 +58,7 @@ export function adapter({ name, aws: { s3, sqs } }) {
   }
 
   return Object.freeze({
+    cleanup: () => interval && clearInterval(interval),
     // list queues
     index: () => getObject(svcName, QUEUES).map(keys).toPromise(),
     // create queue


### PR DESCRIPTION
This is not part of the Queue port spec, but a use case has arose where i'd like to clean up the listening performed by this adapter. This is to prevent memory leaks.

This may be an indication of changes needed in the adapter impl itself, but I could see a broad use case for hyper wanting to "cleanup" an adapter and its resources ie. listeners, events, etc. I don't have enough info to feel confident making a proposal for the port spec, so i've just added it here.

Would this break Zod parsing? 

Looking for thoughts/feedback/approval if we think this fine for now.