### PR TITLE
fix!: resolve hyper error and bubble rejected non-handled exceptions #27

### DIFF
--- a/deps_dev.js
+++ b/deps_dev.js
@@ -1,15 +1,7 @@
 export {
   assert,
   assertEquals,
-} from "https://deno.land/std@0.123.0/testing/asserts.ts";
+  assertThrows,
+} from "https://deno.land/std@0.126.0/testing/asserts.ts";
 
-export { default as appOpine } from "https://x.nest.land/hyper-app-opine@1.2.8/mod.js";
-export { default as core } from "https://x.nest.land/hyper@2.0.0/mod.js";
-export { default as validateFactorySchema } from "https://x.nest.land/hyper@2.0.0/utils/plugin-schema.js";
-
-export {
-  adjectives,
-  animals,
-  colors,
-  uniqueNamesGenerator,
-} from "https://cdn.skypack.dev/unique-names-generator";
+export { default as validateFactorySchema } from "https://x.nest.land/hyper@2.1.1/utils/plugin-schema.js";

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,16 +1,21 @@
 import { crocks, hmac, R } from "../deps.js";
 
-const { Reader } = crocks;
+const { Reader, Async } = crocks;
 const {
-  always,
   cond,
   ifElse,
-  is,
   identity,
   T,
-  join,
   complement,
   isNil,
+  __,
+  isEmpty,
+  defaultTo,
+  is,
+  has,
+  allPass,
+  anyPass,
+  filter,
 } = R;
 
 export const isDefined = complement(isNil);
@@ -24,6 +29,13 @@ export const pluck = R.pluck;
 export const reject = R.reject;
 export const replace = R.replace;
 
+const isEmptyObject = allPass([
+  complement(is(Array)), // not an array
+  is(Object),
+  isEmpty,
+]);
+const rejectNil = filter(isDefined);
+
 export const computeSignature = (secret, payload, time) => {
   const msg = `${time}.${JSON.stringify(payload, null, 0)}`;
 
@@ -31,61 +43,49 @@ export const computeSignature = (secret, payload, time) => {
   return signature;
 };
 
-// always return a string
-export const mapErr = cond([
-  // string
-  [is(String), identity],
-  // { message } catches both Error, and Object with message prop
-  [
-    compose(
-      isDefined,
-      prop("message"),
-    ),
-    prop("message"),
-  ],
-  // { msg }
-  [
-    compose(
-      isDefined,
-      prop("msg"),
-    ),
-    prop("msg"),
-  ],
-  // []
-  [
-    is(Array),
-    compose(
-      join(", "),
-      (errs) => errs.map(mapErr), // recurse
-    ),
-  ],
-  // any non nil
-  [isDefined, (val) => JSON.stringify(val)],
-  // nil
-  [T, () => "An error occurred"],
-]);
-
-// always return a number or undefined
-export const mapStatus = cond([
-  [is(Number), identity],
-  [
-    is(String),
-    compose(
-      ifElse(
-        isNaN,
-        always(undefined),
+/**
+ * Constructs a hyper-esque error
+ *
+ * @typedef {Object} HyperErrArgs
+ * @property {string} msg
+ * @property {string?} status
+ *
+ * @typedef {Object} NotOk
+ * @property {false} ok
+ *
+ * @param {(HyperErrArgs | string)} argsOrMsg
+ * @returns {NotOk & HyperErrArgs} - the hyper-esque error
+ */
+export const HyperErr = (argsOrMsg) =>
+  compose(
+    ({ ok, msg, status }) => rejectNil({ ok, msg, status }), // pick and filter nil
+    assoc("ok", false),
+    cond([
+      [is(String), assoc("msg", __, {})],
+      [
+        anyPass([
+          isEmptyObject,
+          has("msg"),
+          has("status"),
+        ]),
         identity,
-      ),
-      (status) => parseInt(status, 10),
-    ),
-  ],
-  // anything else
-  [T, always(undefined)],
+      ],
+      [T, () => {
+        throw new Error(
+          "HyperErr args must be a string or an object with msg or status",
+        );
+      }],
+    ]),
+    defaultTo({}),
+  )(argsOrMsg);
+
+export const isHyperErr = allPass([
+  has("ok"), // { ok }
+  complement(prop("ok")), // { ok: false }
 ]);
 
-export const toHyperErr = (err) => ({
-  ...err,
-  ok: false,
-  status: mapStatus(err.status),
-  msg: mapErr(err),
-});
+export const handleHyperErr = ifElse(
+  isHyperErr,
+  Async.Resolved,
+  Async.Rejected,
+);

--- a/test/harness.js
+++ b/test/harness.js
@@ -1,14 +1,14 @@
 // Load .env
 import "https://deno.land/x/dotenv@v3.1.0/load.ts";
-
+import { default as appOpine } from "https://x.nest.land/hyper-app-opine@1.3.0/mod.js";
+import { default as core } from "https://x.nest.land/hyper@2.1.1/mod.js";
 import {
   adjectives,
   animals,
-  appOpine,
   colors,
-  core,
   uniqueNamesGenerator,
-} from "../deps_dev.js";
+} from "https://cdn.skypack.dev/unique-names-generator";
+
 import { default as myAdapter, PORT } from "../mod.js";
 
 const name = uniqueNamesGenerator({


### PR DESCRIPTION
Closes #27 

There were no errors being handled in this adapter. Eventually, we may want to handle some specific errors ie. meta file not existing, queue not found (see #18), queue already exists, etc.

This also doesn't include the `addEventListener` api usage for emitting unhealthy state. This will be handled in a separate PR once the error format and schema is determined. For now the `cleanup` api added in #23 get's us most of what we need.

BREAKING CHANGE - caught exceptions are resolved, not rejected, as hyper
errors

The only time a method on the adapter should return a rejected promise
is in the case of an unhandled exception.

Aligns with discussion detailed in:
https://github.com/hyper63/journal/blob/master/design-docs/003-errors.md