### PR TITLE
feat: immediately receive more messages and make sleep configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ export default {
 In order to use this adapter you will need to have an AWS Account and will need
 the following information:
 
-- IAM User with access to SQS (AWS_ACCESS_KEY_ID, AWS_ACCESS_SECRET_KEY)
+- IAM User with access to SQS and S3 (AWS_ACCESS_KEY_ID, AWS_ACCESS_SECRET_KEY,
+  and optional AWS_SESSION_TOKEN)
 - AWS Region (default: us-east-1)
 
 > The AWS User will need the ability to manage s3 and SQS resources
@@ -46,7 +47,8 @@ You may set envrionment variables like so, and the adapter will use them:
 
 ```txt
 AWS_ACCESS_KEY_ID=XXXXX
-AWS_SECRET_ACCESS_KEY=XXXX
+AWS_SECRET_ACCESS_KEY=XXXXX
+AWS_SESSION_TOKEN=XXXXX
 AWS_REGION=XXXXX
 ```
 
@@ -69,22 +71,30 @@ export default {
 };
 ```
 
-> NOTE: You can explictly pass in AwsAccessKeyId, AwsSecretKey, region as
-> options in the adapter method.
-> `sqs(UNIQUE_NAME, { awsAccessKeyId, awsSecretKey, region: 'us-east-1'})`
+You can explictly pass in awsAccessKeyId, awsSecretKey, sessionToken, and region
+as options to the adapter method.
 
-## Example
-
-create queue
-
-```sh
-curl -X PUT -H 'Content-Type: application/json' -d '{"target": "url"}' cloud.hyper.io/queue/hooks
+```js
+sqs(UNIQUE_NAME, {
+  awsAccessKeyId,
+  awsSecretKey,
+  sessionToken,
+  region: "us-east-1",
+});
 ```
 
-post queue
+## Sleep
 
-```sh
-curl -X POST -H 'Content-Type: application/json' -d '{...}' cloud.hyper.io/queue/hooks
+This adapter's process task receives messages from SQS and sends them to your
+queue's worker url for processing. If no messages are received from SQS, this
+adapter's process task will pause, by default, for 10 seconds, before attempting
+to receive more messages from SQS
+
+You can also pass a `sleep` value to the adapter, which should be the number of
+milliseconds to pause if no messages are received from SQS:
+
+```js
+sqs(UNIQUE_NAME, { sleep: 5000, awsAccessKeyId: ...})
 ```
 
 ## Installation

--- a/mod.js
+++ b/mod.js
@@ -21,15 +21,31 @@ const {
 export const PORT = "queue";
 
 /**
+ * @typedef {Object} SqsAdapterOptions
+ * @property {number} [sleep] - the number of milliseconds to wait
+ * to receive more jobs, if no jobs were recevied on the previous
+ * process task
+ * @property {string} [awsAccessKeyId] - the AWS Access Key ID to use. Defaults to Environment AWS_ACCESS_KEY_ID
+ * @property {string} [awsSecretKey] - the AWS Secret Key to use. Defaults to Environment AWS_SECRET_ACCESS_KEY
+ * @property {string} [sessionToken] - the AWS Session Token to use. Defaults to Environment AWS_SESSION_TOKEN
+ * @property {string} [region] - the AWS Region to use. Defaults to Environment AWS_REGION
+ *
  * @param {string} svcName - name of queue service
- * @param {object} [options] - optional set of config options for adapter
+ * @param {SqsAdapterOptions} [options] - optional set of config options for adapter
  */
 export default function sqsAdapter(svcName, options = {}) {
   const setNameOn = (obj) => assoc("name", __, obj);
-  const setAwsCreds = (env) =>
+  // sleep, aws credentials
+  const setOptions = (env) =>
     mergeRight(
       env,
       reject(isNil, options),
+    );
+
+  const setSleep = (env) =>
+    mergeRight(
+      { sleep: 10000 },
+      env,
     );
   const setAwsRegion = (env) =>
     mergeRight(
@@ -76,7 +92,8 @@ export default function sqsAdapter(svcName, options = {}) {
           notIsNull(svcName)
             .map(setNameOn(env))
         )
-        .map(setAwsCreds)
+        .map(setOptions)
+        .map(setSleep)
         .map(setAwsRegion)
         .map(createFactory)
         .map(loadAws)

--- a/mod.test.js
+++ b/mod.test.js
@@ -23,8 +23,9 @@ test("load - should return the object", () => {
   assert(res.aws.sqs);
 });
 
-test("load - should use provided credentials", async () => {
+test("load - should use provided options", async () => {
   const res = createFactory("foo", {
+    sleep: 1000,
     awsAccessKeyId: "foo",
     awsSecretKey: "bar",
     region: "fizz",
@@ -33,10 +34,12 @@ test("load - should use provided credentials", async () => {
   await res.factory.ensureCredentialsAvailable();
 
   assert(true);
+  assertEquals(res.sleep, 1000);
 });
 
-test("load - should use credentials passed to load", async () => {
+test("load - should use options passed to load", async () => {
   const res = createFactory("foo").load({
+    sleep: 1000,
     awsAccessKeyId: "foo",
     awsSecretKey: "bar",
     region: "fizz",
@@ -44,18 +47,23 @@ test("load - should use credentials passed to load", async () => {
 
   await res.factory.ensureCredentialsAvailable();
   assert(true);
+  assertEquals(res.sleep, 1000);
 });
 
-test("load - should merge credentials, preferring those passed to adapter", async () => {
-  const res = createFactory("foo", { awsAccessKeyId: "better-id" }).load({
-    awsAccessKeyId: "foo",
-    awsSecretKey: "bar",
-    region: "fizz",
-  });
+test("load - should merge options, preferring those passed to adapter", async () => {
+  const res = createFactory("foo", { sleep: 1000, awsAccessKeyId: "better-id" })
+    .load({
+      sleep: 2000,
+      awsAccessKeyId: "foo",
+      awsSecretKey: "bar",
+      region: "fizz",
+    });
 
   await res.factory.ensureCredentialsAvailable();
 
+  assertEquals(res.name, "foo");
   assertEquals(res.awsAccessKeyId, "better-id");
+  assertEquals(res.sleep, 1000);
   assertEquals(res.awsSecretKey, "bar");
   assertEquals(res.region, "fizz");
 });
@@ -69,4 +77,9 @@ test("load - should default the region to us-east-1", async () => {
   await res.factory.ensureCredentialsAvailable();
 
   assertEquals(res.region, "us-east-1");
+});
+
+test("load - should default the sleep to 10000", () => {
+  const res = createFactory("foo").load();
+  assertEquals(res.sleep, 10000);
 });

--- a/test/harness.js
+++ b/test/harness.js
@@ -19,7 +19,7 @@ const name = uniqueNamesGenerator({
 const hyperConfig = {
   app: appOpine,
   adapters: [
-    { port: PORT, plugins: [myAdapter(name)] },
+    { port: PORT, plugins: [myAdapter("timeout-test")] },
   ],
 };
 


### PR DESCRIPTION
This adapter has a `setInterval`, which receives messages from SQS every 10 seconds.

However, in load tests, the messages were not being processed off the SQS queue quickly enough resulting in a backup. Receive messages is already set at the max that SQS allows: 10 messages at a time.

So instead, this PR changes the `setInterval` into a `setTimeout`. If the `processTasks` processes any messages, the adapter will wait for 500 ms, then ask SQS for more. If no messages were received, or an error occurred processing jobs, then the adapter will sleep for 10 seconds, by default. This amount is configurable via a `sleep` option passed to the adapter.

This results in constantly receiving messages from SQS, _unless_ the queue is empty or an error occurs, which will trigger a pause, then rinse and repeat.

Also closes #16 with updates to the README