### PR TITLE
fix: catch race condition between listing keys and fetching each object #38

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -55,6 +55,14 @@ export const isAwsNonExistentQueueErr = allPass([
   ),
 ]);
 
+export const isAwsNoSuchKeyErr = allPass([
+  has("message"),
+  propSatisfies(
+    includes("NoSuchKey"),
+    "message",
+  ),
+]);
+
 export const handleHyperErr = ifElse(
   isHyperErr,
   Async.Resolved,


### PR DESCRIPTION
Closes #38 

This PR catches that race condition, and returns a "stub job" with status `PROCESSED`