### PR TITLE
feat(process): parallelize processTasks, not message processing within processTasks

### DIFF
--- a/deps_dev.js
+++ b/deps_dev.js
@@ -2,6 +2,6 @@ export {
   assert,
   assertEquals,
   assertThrows,
-} from "https://deno.land/std@0.132.0/testing/asserts.ts";
+} from "https://deno.land/std@0.147.0/testing/asserts.ts";
 
 export { default as validateFactorySchema } from "https://x.nest.land/hyper@3.0.1/utils/plugin-schema.js";

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -82,3 +82,5 @@ export const asyncifyMapTokenErrs = (fn) =>
           throw err;
         }),
   );
+
+export const logger = (name) => (...args) => console.log(`[${name}]:`, ...args);

--- a/mod.js
+++ b/mod.js
@@ -47,6 +47,13 @@ export default function sqsAdapter(svcName, options = {}) {
       { sleep: 10000 },
       env,
     );
+
+  const setConcurrency = (env) =>
+    mergeRight(
+      { concurrency: 20 },
+      env,
+    );
+
   const setAwsRegion = (env) =>
     mergeRight(
       { region: "us-east-1" },
@@ -94,6 +101,7 @@ export default function sqsAdapter(svcName, options = {}) {
         )
         .map(setOptions)
         .map(setSleep)
+        .map(setConcurrency)
         .map(setAwsRegion)
         .map(createFactory)
         .map(loadAws)

--- a/mod.test.js
+++ b/mod.test.js
@@ -26,6 +26,7 @@ test("load - should return the object", () => {
 test("load - should use provided options", async () => {
   const res = createFactory("foo", {
     sleep: 1000,
+    concurrency: 15,
     awsAccessKeyId: "foo",
     awsSecretKey: "bar",
     region: "fizz",
@@ -35,6 +36,7 @@ test("load - should use provided options", async () => {
 
   assert(true);
   assertEquals(res.sleep, 1000);
+  assertEquals(res.concurrency, 15);
 });
 
 test("load - should use options passed to load", async () => {
@@ -82,4 +84,9 @@ test("load - should default the region to us-east-1", async () => {
 test("load - should default the sleep to 10000", () => {
   const res = createFactory("foo").load();
   assertEquals(res.sleep, 10000);
+});
+
+test("load - should default the concurrency to 20", () => {
+  const res = createFactory("foo").load();
+  assertEquals(res.concurrency, 20);
 });

--- a/process-tasks.js
+++ b/process-tasks.js
@@ -11,7 +11,14 @@ const { Async } = crocks;
 export default function (
   svcName,
   asyncFetch,
-  { getQueueUrl, receiveMessage, deleteMessage, putObject, deleteObject },
+  {
+    getQueueUrl,
+    receiveMessage,
+    deleteMessage,
+    putObject,
+    deleteObject,
+    log,
+  },
 ) {
   const setToErrorState = (txt, msg) =>
     compose(
@@ -88,7 +95,7 @@ export default function (
   }
 
   return getQueueUrl(svcName)
-    .chain((url) => receiveMessage(url, 10))
+    .chain((url) => receiveMessage(url, 1))
     // post messages to target
     .chain((msgs) => Async.all(map(postMessages(svcName), msgs)))
     .bichain((err) => {
@@ -99,7 +106,7 @@ export default function (
       }
 
       if (isAwsNonExistentQueueErr(err)) {
-        console.log("Queue is not created. Mapping to no jobs.");
+        log("Queue is not created. Mapping to no jobs.");
         return Async.Resolved([]);
       }
 

--- a/process-tasks_test.js
+++ b/process-tasks_test.js
@@ -5,7 +5,7 @@ import { assert, assertEquals } from "./deps_dev.js";
 
 import aws from "./aws-mock.js";
 import processTasks from "./process-tasks.js";
-import { computeSignature } from "./lib/utils.js";
+import { computeSignature, logger } from "./lib/utils.js";
 
 const { s3, sqs } = aws;
 const { Async } = crocks;
@@ -44,6 +44,7 @@ test("receive messages", async () => {
     deleteMessage,
     putObject,
     deleteObject,
+    log: logger(0),
   })
     .toPromise();
   assertEquals(result[0].ok, true);
@@ -56,6 +57,7 @@ test("map token error to HyperErr", async () => {
     deleteMessage,
     putObject,
     deleteObject,
+    log: logger(0),
   })
     .toPromise().catch((e) => e);
   assertEquals(result.ok, false);
@@ -77,6 +79,7 @@ test("failed to send to worker - mark job as error", async () => {
       return Async.fromPromise(s3.putObject)(a, b, c);
     }),
     deleteObject,
+    log: logger(0),
   })
     .toPromise();
   assertEquals(result[0].ok, true);
@@ -119,6 +122,7 @@ test("computes a signature", async () => {
     deleteMessage,
     putObject,
     deleteObject,
+    log: logger(0),
   })
     .toPromise();
   assertEquals(result[0].ok, true);

--- a/test/harness.js
+++ b/test/harness.js
@@ -1,7 +1,7 @@
 // Load .env
 import "https://deno.land/x/dotenv@v3.1.0/load.ts";
-import { default as appOpine } from "https://x.nest.land/hyper-app-opine@1.3.0/mod.js";
-import { default as core } from "https://x.nest.land/hyper@2.1.1/mod.js";
+import { default as appOpine } from "https://x.nest.land/hyper-app-opine@2.1.0/mod.js";
+import { default as core } from "https://x.nest.land/hyper@3.2.2/mod.js";
 import {
   adjectives,
   animals,


### PR DESCRIPTION
Instead of 1 task, processing {concurrency} messages at a time:
```
[x,x,x,x,x,x,x] -> [x,x,x,x,x,x,x] -> ....
```

We use {concurrency} tasks, each processing 1 message a time:
```
[
[x] -> [x] -> [x] -> [x] -> ...
[x] -> [x] -> ...
[x] -> [x] -> [x] -> ...
]
```

This hedges against long-processing messages from stalling all message retrieval and processing